### PR TITLE
logging: import Literal from typing

### DIFF
--- a/bubop/logging.py
+++ b/bubop/logging.py
@@ -2,12 +2,11 @@
 import logging
 import logging.handlers
 import sys
-from typing import Mapping
+from typing import Literal, Mapping
 
 import loguru
 import tqdm
 from loguru import logger  # pylint: disable=W0611
-from typing_extensions import Literal
 
 LoguruLogLevel = Literal[
     "FATAL",


### PR DESCRIPTION
Instead of typing_extensions, which isn't a dependency of this package.
`typing.Literal` was introduced in Python 3.8[0], which is the lowest
version supported by bubop.

[0] https://docs.python.org/3/library/typing.html#typing.Literal