### PR TITLE
make crypto read_gpg_token timeout configurable

### DIFF
--- a/bubop/crypto.py
+++ b/bubop/crypto.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 
 
-def read_gpg_token(p: Path, timeout: int = 3) -> str:
+def read_gpg_token(p: Path, timeout_secs: int = 3) -> str:
     """Read the token from a gpg file.
 
     Raise a RuntimeError if the decryption was unsuccessful.
@@ -13,7 +13,7 @@ def read_gpg_token(p: Path, timeout: int = 3) -> str:
         raise RuntimeError("gpg is required but it's not installed.")
 
     proc = subprocess.run(
-        ["gpg", "--decrypt", "-q", str(p)], capture_output=True, timeout=timeout, check=True
+        ["gpg", "--decrypt", "-q", str(p)], capture_output=True, timeout=timeout_secs, check=True
     )
     return proc.stdout.decode("utf-8").rstrip("\n")
 

--- a/bubop/crypto.py
+++ b/bubop/crypto.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 
 
-def read_gpg_token(p: Path) -> str:
+def read_gpg_token(p: Path, timeout: int = 3) -> str:
     """Read the token from a gpg file.
 
     Raise a RuntimeError if the decryption was unsuccessful.
@@ -13,7 +13,7 @@ def read_gpg_token(p: Path) -> str:
         raise RuntimeError("gpg is required but it's not installed.")
 
     proc = subprocess.run(
-        ["gpg", "--decrypt", "-q", str(p)], capture_output=True, timeout=3, check=True
+        ["gpg", "--decrypt", "-q", str(p)], capture_output=True, timeout=timeout, check=True
     )
     return proc.stdout.decode("utf-8").rstrip("\n")
 


### PR DESCRIPTION
I'm using `taskwarrior_syncall` (great project), and I can't type in my password before the hard-coded 3 second timeout! Would like to make this configurable so I can set something like `--token-pass-timeout` to override this. Or we could increase the timeout if you're comfortable with that.